### PR TITLE
Open dumps with wrong checksum

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -126,7 +126,6 @@ void MainWindow::openFile(){
                 this,
                 appName,
                 tr("JEDEC section checksum error, will be fixed by saving.") );
-            return;
         }
 
         enableUI();


### PR DESCRIPTION
Allow software to proceed while opening file with incorrect CRC to fix it as message actually suggests. It does the job of updating CRC to correct value on save indeed, so no need to return here.